### PR TITLE
Expanded example descriptions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,14 +12,14 @@ $ npm run <example name> # eg. 01-session
 ```
 
 ## Examples
-  * [session](./src/01-session.ts) -- createSession and syncAccount
-    * [state storage](./src/02-state-storage.ts) -- get and set state
-    * [contract account](./src/03-contract-account.ts) -- get account and members, topUpAccount
-    * [ens](./src/04-ens.ts) -- reserve ENS name
-    * [p2p payments](./src/05-p2p-payments.ts) -- send payments across a payment channel
-    * [payment hub](./src/06-payment-hub.ts) -- deposits and payments in a payment hub
-    * [payment hub bridge](./src/07-payment-hub-bridge.ts) -- payments across a bridge
-    * [gateway](./src/08-gateway.ts) -- send transaction batch using gateway
-    * [projects](./src/09-projects.ts) -- call current project and add account owners
-    * [assets](./src/10-assets.ts) -- get token list for account
-    * [external contracts](./src/11-external-contracts.ts) -- transactions to ERC20 contract accounts
+* [session](./src/01-session.ts) -- createSession and syncAccount
+* [state storage](./src/02-state-storage.ts) -- get and set state
+* [contract account](./src/03-contract-account.ts) -- get account and members, topUpAccount
+* [ens](./src/04-ens.ts) -- reserve ENS name
+* [p2p payments](./src/05-p2p-payments.ts) -- send payments across a payment channel
+* [payment hub](./src/06-payment-hub.ts) -- deposits and payments in a payment hub
+* [payment hub bridge](./src/07-payment-hub-bridge.ts) -- payments across a bridge
+* [gateway](./src/08-gateway.ts) -- send transaction batch using gateway
+* [projects](./src/09-projects.ts) -- call current project and add account owners
+* [assets](./src/10-assets.ts) -- get token list for account
+* [external contracts](./src/11-external-contracts.ts) -- transactions to ERC20 contract accounts

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,5 @@
 # ETHERspot sdk examples
+These examples show how to combine the sdk calls to perform common functions.
 
 ## Prerequisites
 
@@ -9,3 +10,16 @@
 ```bash
 $ npm run <example name> # eg. 01-session
 ```
+
+## Examples
+  * [session](./src/01-session.ts) -- createSession and syncAccount
+    * [state storage](./src/02-state-storage.ts) -- get and set state
+    * [contract account](./src/03-contract-account.ts) -- get account and members, topUpAccount
+    * [ens](./src/04-ens.ts) -- reserve ENS name
+    * [p2p payments](./src/05-p2p-payments.ts) -- send payments across a payment channel
+    * [payment hub](./src/06-payment-hub.ts) -- deposits and payments in a payment hub
+    * [payment hub bridge](./src/07-payment-hub-bridge.ts) -- payments across a bridge
+    * [gateway](./src/08-gateway.ts) -- send transaction batch using gateway
+    * [projects](./src/09-projects.ts) -- call current project and add account owners
+    * [assets](./src/10-assets.ts) -- get token list for account
+    * [external contracts](./src/11-external-contracts.ts) -- transactions to ERC20 contract accounts


### PR DESCRIPTION
etherspot.net now links to this page, so I added a list of the examples along with a short description. Please edit if not correct. I noticed that you removed the list of examples from the main readme page, could we include a single link on the main page to this one?