### PR TITLE
Fixes to ms-rates and scripts

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -21,9 +21,10 @@
     "13-transactions": "../node_modules/.bin/ts-node ./src/13-transactions",
     "14-delayed-transactions": "../node_modules/.bin/ts-node ./src/14-delayed-transactions",
     "15-topup-fuctions": "../node_modules/.bin/ts-node ./src/15-topup-fuctions",
-    "16-cross-chain-quote": "../node_modules/.bin/ts-node ./src/16-cross-chain-quote.ts",
+    "16-cross-chain-quotes": "../node_modules/.bin/ts-node ./src/16-cross-chain-quotes.ts",
     "17-superFluids-createStream": "../node_modules/.bin/ts-node ./src/17-superFluids-createStream.ts",
-    "18-cross-chain-stream": "../node_modules/.bin/ts-node ./src/18-cross-chain-stream.ts"
+    "18-cross-chain-stream": "../node_modules/.bin/ts-node ./src/18-cross-chain-stream.ts",
+    "21-exchange-rates": "../node_modules/.bin/ts-node ./src/21-exchange-rates.ts"
   },
   "dependencies": {
     "dotenv": "16.0.1"

--- a/examples/src/21-exchange-rates.ts
+++ b/examples/src/21-exchange-rates.ts
@@ -11,7 +11,7 @@ async function main(): Promise<void> {
   const ETH_CHAIN_ID = 1;
 
   const wallet = randomWallet();
-  const sdk = new Sdk(wallet, { env: EnvNames.LocalNets, networkName: NetworkNames.Mainnet });
+  const sdk = new Sdk(wallet, { env: EnvNames.MainNets, networkName: NetworkNames.Mainnet });
   await sdk.computeContractAccount();
 
   const requestPayload = {


### PR DESCRIPTION
## Description
- Added fix for cross chain rates script (issue with example name and package.json script name not matching)
- Added script for running 21-exchange-rates to package.json
- Changed SDK env to mainnet from localnets
- Tested example code for exchange rates (21)

## Motivation and Context
- Fix for package.json script to match example name
- Added script for running exchange rates example

## How Has This Been Tested?
- Tested locally using example 21


## Screenshots (if appropriate):
![Screenshot 2022-09-16 at 09 17 04](https://user-images.githubusercontent.com/71776468/190592008-0e3e504e-1b10-40b9-9957-14ec4a728a64.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)