### PR TITLE
Arbitrum Nova/Nitro support | bump version to 1.36.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "etherspot",
-  "version": "1.36.0",
+  "version": "1.36.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "etherspot",
-      "version": "1.36.0",
+      "version": "1.36.5",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etherspot",
-  "version": "1.36.0",
+  "version": "1.36.5",
   "description": "Etherspot SDK",
   "keywords": [
     "ether",


### PR DESCRIPTION
## Description
- Bumped version to 1.36.5 (from 1.36.0)

## Motivation and Context


## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)