### PR TITLE
Change naming of Connext service provider to 'Etherspot'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "etherspot",
-  "version": "1.43.7",
+  "version": "1.43.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "etherspot",
-      "version": "1.43.7",
+      "version": "1.43.8",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etherspot",
-  "version": "1.43.7",
+  "version": "1.43.8",
   "description": "Etherspot SDK",
   "keywords": [
     "ether",

--- a/src/sdk/exchange/constants.ts
+++ b/src/sdk/exchange/constants.ts
@@ -15,7 +15,7 @@ export enum SocketTokenDirection {
 export enum CrossChainServiceProvider {
   SocketV2 = 'SocketV2',
   LiFi = 'LiFi',
-  Connext = 'Connext',
+  Etherspot = 'Connext',
 }
 
 export enum LiFiBridge {
@@ -29,5 +29,5 @@ export enum LiFiBridge {
   multichain = 'multichain',
   optimism = 'optimism',
   polygon = 'polygon',
-  stargate = 'stargate'
+  stargate = 'stargate',
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Changes 'Connext' to 'Etherspot' for SDK requests. 
- Tested Connext backend integration via example 16 get cross chain quotes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- To name this [service identifier](https://sdk.etherspot.dev/classes/getexchangecrosschainquotedto.html#serviceprovider) as  "Etherspot" for incoming requests from the SDK via the [getCrossChainQuotes](https://sdk.etherspot.dev/classes/sdk.html#getcrosschainquotes) method

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested by running cross chain quote example (modified) to check that results are returned when using 'Etherspot' as the service provider (see screenshots).


## Screenshots (if appropriate):
![Screen Shot 2023-07-04 at 11 02 51](https://github.com/etherspot/etherspot-sdk/assets/71776468/e40b553c-fa47-4bf9-bc02-e43b3e15c905)

![Connext TEST-TEST quote](https://github.com/etherspot/etherspot-sdk/assets/71776468/394738aa-fd5f-4868-ad96-bba34e5eb7a5)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)